### PR TITLE
aria-labeledby should be aria-labelledby (British spelling)

### DIFF
--- a/src/js/badger-accordion.js
+++ b/src/js/badger-accordion.js
@@ -443,7 +443,7 @@ class BadgerAccordion {
         // Adding ID & aria-controls
         this._setupHeaders();
 
-        // Adding ID & aria-labeledby
+        // Adding ID & aria-labelledby
         this._setupPanels();
 
         // Inserting data-attribute onto each `header`
@@ -511,7 +511,7 @@ class BadgerAccordion {
     _setupPanels() {
         this.panels.forEach( (panel, index) => {
             panel.setAttribute('id', `badger-accordion-panel-${this.ids[index].id}`);
-            panel.setAttribute('aria-labeledby', `badger-accordion-header-${this.ids[index].id}`);
+            panel.setAttribute('aria-labelledby', `badger-accordion-header-${this.ids[index].id}`);
             if(this.settings.roles === true || this.settings.roles.region !== false) {
                 this._setRole('region', panel);
             }


### PR DESCRIPTION
This got caught by one of our testing tools. 

Apologies is this isn't the correct way to raise a PR. I wasn't sure whether I needed to build the dist files or if you do those on release. I can update it if you need me to.

For reference: https://www.w3.org/TR/wai-aria/#aria-labelledby

> NOTE
> The expected spelling of this property in U.S. English is "labeledby." However, the accessibility API features to which this property is mapped have established the "labelledby" spelling. This property is spelled that way to match the convention and minimize the difficulty for developers.